### PR TITLE
Fixes #481 (Jobs status page access control check)

### DIFF
--- a/jobs/app/controllers/status.go
+++ b/jobs/app/controllers/status.go
@@ -12,8 +12,12 @@ type Jobs struct {
 }
 
 func (c Jobs) Status() revel.Result {
-	if _, ok := c.Request.Header["X-Forwarded-For"]; ok || !strings.HasPrefix(c.Request.RemoteAddr, "127.0.0.1:") {
-		return c.Forbidden("%s is not local", c.Request.RemoteAddr)
+	remoteAddress := c.Request.RemoteAddr
+	if proxiedAddress, isProxied := c.Request.Header["X-Forwarded-For"]; isProxied {
+		remoteAddress = proxiedAddress[0]
+	}
+	if !strings.HasPrefix(remoteAddress, "127.0.0.1") && !strings.HasPrefix(remoteAddress, "::1") {
+		return c.Forbidden("%s is not local", remoteAddress)
 	}
 	entries := jobs.MainCron.Entries()
 	return c.Render(entries)


### PR DESCRIPTION
PR for revel/revel#481

I verified that direct, localhost request and proxied nginx request allows access to status page and denies access for non-IPv4 local loopback. Did not test IPv6, but the logic is sound ("::1" is IPv6 local loopback address).