### PR TITLE
Testrunner bootstrap panels

### DIFF
--- a/testrunner/app/views/TestRunner/Index.html
+++ b/testrunner/app/views/TestRunner/Index.html
@@ -78,13 +78,13 @@
 
     $(function() {
         var divId, visible;
-		//close any panels that were previously closed.
+        //close any panels that were previously closed.
         $("div.panel-collapse").each(function() {
             divId = "#" + $(this).attr("id");
             visible = localStorage.getItem("testrunner_" + divId);
             if (visible == "false") {
                 $(divId).css("height", "0").removeClass("in"); //this is the way bootstrap does it.
-				$("a[data-target=" + divId + "]").addClass("collapsed");
+                $("a[data-target=" + divId + "]").addClass("collapsed");
             }
         });
     });

--- a/testrunner/app/views/TestRunner/Index.html
+++ b/testrunner/app/views/TestRunner/Index.html
@@ -1,110 +1,190 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>Revel Test Runner</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-		<link href="{{url `Root`}}/@tests/public/css/bootstrap.min.css" type="text/css" rel="stylesheet"></link>
-		<link href="{{url `Root`}}/@tests/public/css/github.css" type="text/css" rel="stylesheet"></link>
-		<script src="{{url `Root`}}/@tests/public/js/jquery-1.9.1.min.js" type="text/javascript"></script>
-		<script src="{{url `Root`}}/@tests/public/js/bootstrap.min.js" type="text/javascript"></script>
-		<script src="{{url `Root`}}/@tests/public/js/highlight.pack.js" type="text/javascript"></script>
-		<style>
-		header { padding:20px 0; background-color:#ADD8E6 }
-		.passed td { background-color: #90EE90 !important; }
-		.failed td { background-color: #FFB6C1 !important; }
-		.tests td.name, .tests td.result { padding-top: 13px; }
-		pre { font-size:10px; white-space: pre; }
-		.name { width: 25%; }
-		.w100 { width: 100%; }
-		</style>
-	</head>
-	<body>
-		<header>
-			<div class="container">
-				<table class="w100"><tr><td>
-					<h1>Test Runner</h1>
-					<p class="lead">Run all of your application's tests from here.</p>
-				</td><td style="padding-left:150px;" class="text-right">
-					<button class="btn btn-lg btn-success" all-tests="">Run All Tests</button>
-				</td></tr></table>
-			</div>
-		</header>
+    <head>
+        <title>Revel Test Runner</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <link href="{{url `Root`}}/@tests/public/css/bootstrap.min.css" type="text/css" rel="stylesheet"></link>
+        <link href="{{url `Root`}}/@tests/public/css/github.css" type="text/css" rel="stylesheet"></link>
+        <script src="{{url `Root`}}/@tests/public/js/jquery-1.9.1.min.js" type="text/javascript"></script>
+        <script src="{{url `Root`}}/@tests/public/js/bootstrap.min.js" type="text/javascript"></script>
+        <script src="{{url `Root`}}/@tests/public/js/highlight.pack.js" type="text/javascript"></script>
+        <style>
+        header { background-color:#ADD8E6 }
+        header h1 {margin-top: 10px; margin-bottom:20px;}
+        header table {margin-bottom: 0px }
+        td .btn {margin-bottom: 1px; line-height: 1.0}
+        button.file-test { margin-bottom: 0px; margin-left: 2px }
+        table.tests tr { border-bottom: 1px solid #ddd; background-color: #f9f9f9; }
+        .table > tbody > tr > td { padding-top:1px; padding-bottom:2px; vertical-align: middle; }
+        .passed td { background-color: #90EE90 !important; }
+        .failed td { background-color: #FFB6C1 !important; }
+        .tests td.name, .tests td.result { }
+        pre { font-size:10px; white-space: pre; }
+        .panel-heading {
+            padding: 2px 2px
+        }
+        .panel-heading a:after {
+            margin-top:4px;
+            margin-right:4px;
+            content:"\25bc";
+            float: right;
+            color: grey;
+        }
+        .panel-heading a.collapsed:after {
+            content:"\25b6";
+        }
+        .name { width: 50%; }
+        .w100 { width: 100%; }
+        </style>
+    </head>
+    <body>
+        <header>
+            <div class="container">
+                <h1 class="pull-left">Test Runner <small>- Run your unit tests here.</small> </h1>
+                    <div style="margin-top:8px" class="pull-right">
+                        <button class="btn btn-success" all-tests="">Run All Tests</button>
+                        <div><a class="small" href="#" id="allTestResults"></a></div>
+                    </div>
+            </div>
+        </header>
+        <div class="panel-group container">
+            {{range .testSuites}}
+            {{ $testFile := .Name }}
+            <div style="margin-top:10px;" class="panel panel-default">
+                <div class="panel-heading">
+                    <button class="btn btn-xs btn-success file-test" test-file="{{.Name}}" class="btn btn-success btn-xs">Run</button>
+                    <span class="h5">&nbsp;<a class="collapseLnk" data-toggle="collapse" data-target="#{{.Name}}" href="#">{{.Name}}</a></span>
+                </div>
+                <div id="{{.Name}}" class="panel-collapse collapse in">
+                    <table class="panel-body table table-condensed tests" suite="{{.Name}}">
+                        {{range .Tests}}
+                            <tr>
+                                <td class="name"><button data-test-file="{{$testFile}}" test="{{.Name}}" class="leftbutton btn btn-success btn-xs">Run</button>&nbsp;&nbsp;{{ .Name }}</td>
+                                <td class="result"></td>
+                                <td><button data-test-file="{{$testFile}}" test="{{.Name}}" class="pull-right btn btn-success btn-xs">Run</button></td>
+                            </tr>
+                        {{end}}
+                    </table>
+                </div>
+            </div>
+            {{end}}
+        </div>
 
-		<div class="container">
-			{{range .testSuites}}
-				<p class="lead" style="margin-top:20px;">{{.Name}}</p>
-				<table class="table table-striped tests" suite="{{.Name}}">
-					{{range .Tests}}
-						<tr>
-							<td class="name">{{.Name}}</td>
-							<td class="result">
-							</td>
-							<td class="text-right"><button test="{{.Name}}" class="btn btn-success">Run</button></td>
-						</tr>
-					{{end}}
-				</table>
-			{{end}}
-		</div>
+    <script>
+    var passCount = 0;
+    var failCount = 0;
+    var buttons = [];
+    var running;
 
-	<script>
-	var buttons = [];
-	var running;
+    $(function() {
+        var divId, visible;
+		//close any panels that were previously closed.
+        $("div.panel-collapse").each(function() {
+            divId = "#" + $(this).attr("id");
+            visible = localStorage.getItem("testrunner_" + divId);
+            if (visible == "false") {
+                $(divId).css("height", "0").removeClass("in"); //this is the way bootstrap does it.
+				$("a[data-target=" + divId + "]").addClass("collapsed");
+            }
+        });
+    });
 
-	$("button[test]").click(function() {
-		var button = $(this).addClass("disabled").text("Running");
-		addToQueue(button);
-	});
+    $(".fileTestLnk").click(function() {
+        var tableId = $(this).attr("href");
+        $(tableId).toggle();
+        return false;
+    });
 
-	$("button[all-tests]").click(function() {
-		var button = $(this).addClass("disabled").text("Running");
-		$("button[test]").click();
-	});
+    $("#allTestResults").click(function() {
+        var badRow = $("tr.failed").get(0);
+        if (badRow !== undefined) 
+            badRow.scrollIntoView();
 
-	function addToQueue(button) {
-		buttons.push(button);
-		if (!running) {
-			running = true;
-			nextTest();
-		}
-	}
+        return false;
+    });
 
-	function nextTest() {
-		if (buttons.length == 0) {
-			running = false;
-		} else {
-			var next = buttons.shift();
-			runTest(next);
-		}
-	}
+    $("button[test]").click(function() {
+        $("#allTestResults").text("");
+        var button = $(this).addClass("disabled").text("Running");
+        $(this).closest("tr").removeClass("passed").removeClass("failed");
+        addToQueue(button);
+    });
 
-	function runTest(button) {
-		var suite = button.parents("table").attr("suite");
-		var test = button.attr("test");
-		var row = button.parents("tr");
-		var resultCell = row.children(".result");
-		$.ajax({
-			dataType: "json",
-			url: "{{url `Root`}}/@tests/"+suite+"/"+test,
-			success: function(result) {
-				row.attr("class", result.Passed ? "passed" : "failed");
-				if (result.Passed) {
-					resultCell.html("");
-				} else {
-					resultCell.html(result.ErrorHTML);
+    $("button[test-file]").click(function() {
+        $("#allTestResults").text("");
+        var testfile = $(this).attr('test-file');
+        $("button").each(function() {
+            if ($(this).data("test-file") == testfile)
+                $(this).click();
+        });
+    });
 
-					$("#result_" + suite + "_" + test + " pre code").each(function(i, block) {
-						hljs.highlightBlock(block);
-					});
-				}
-				button.removeClass("disabled").text("Run");
-				if (buttons.length == 0) {
-					$("button[all-tests]").removeClass("disabled").text("Run All Tests");
-				}
-				nextTest();
-			}
-		});
-	}
-	</script>
+    $("button[all-tests]").click(function() {
+        $("tr").removeClass("passed").removeClass("failed");
+        passCount = 0;
+        failCount = 0;
+        var button = $(this).addClass("disabled").text("Running");
+        $("button.leftbutton[test]").click();
+    });
 
-	</body>
+    $("a.collapseLnk").click(function() {
+        var tableId = $(this).data("target");
+        var visible = !$(tableId).is(":visible");
+        localStorage.setItem("testrunner_" + tableId, visible);
+    });
+
+    function addToQueue(button) {
+        buttons.push(button);
+        if (!running) {
+            running = true;
+            nextTest();
+        }
+    }
+
+    function nextTest() {
+        if (buttons.length == 0) {
+            running = false;
+        } else {
+            var next = buttons.shift();
+            runTest(next);
+        }
+    }
+
+    function runTest(button) {
+        var suite = button.parents("table").attr("suite");
+        var test = button.attr("test");
+        var row = button.parents("tr");
+        var resultCell = row.children(".result");
+        $.ajax({
+            dataType: "json",
+            url: "{{url `Root`}}/@tests/"+suite+"/"+test,
+            success: function(result) {
+                row.attr("class", result.Passed ? "passed" : "failed");
+                if (result.Passed) {
+                    console.log("pass: " + result.Name);
+                    passCount++;
+                    resultCell.html("");
+                } else {
+                    console.log("fail: result.Name");
+                    failCount++;
+                    resultCell.html(result.ErrorHtml);
+
+                    $("#result_" + suite + "_" + test + " pre code").each(function(i, block) {
+                        hljs.highlightBlock(block);
+                    });
+                }
+                button.removeClass("disabled").text("Run");
+                var runAllBut = $("button[all-tests]");
+                if (buttons.length == 0 && runAllBut.hasClass("disabled")) {
+                    runAllBut.removeClass("disabled").text("Run All Tests");
+                    var resMsg = passCount + " passed, " + failCount + " failed.";
+                    $("#allTestResults").text(resMsg);
+                }
+                nextTest();
+            }
+        });
+    }
+    </script>
+
+    </body>
 </html>


### PR DESCRIPTION
Enclose test group in collapsible bootstrap panels
   - use standard BS classes but tweak style to condense layout
   - store open/close state in localstorage
   - restore state on refresh by directly setting panel height to 0
![testrunner_collapse_panels](https://cloud.githubusercontent.com/assets/1987922/6889145/fd8362de-d644-11e4-85b7-31732d4ffda6.png)
