### PR TITLE
Display test suites in sorted order

### DIFF
--- a/testrunner/app/controllers/testrunner.go
+++ b/testrunner/app/controllers/testrunner.go
@@ -192,15 +192,15 @@ func describeSuite(testSuite interface{}) TestSuiteDesc {
 
 // errorSummary gets an error and returns its summary in human readable format.
 func errorSummary(err *revel.Error) (message string) {
-	EXPECTED_PREFIX := "(expected)"
-	ACTUAL_SUFFIX := "(actual)"
+	expected_prefix := "(expected)"
+	actual_prefix := "(actual)"
 	errDesc := err.Description
 	//strip the actual/expected stuff to provide more condensed display.
-	if strings.Index(errDesc, EXPECTED_PREFIX) == 0 {
-		errDesc = errDesc[len(EXPECTED_PREFIX):len(errDesc)]
+	if strings.Index(errDesc, expected_prefix) == 0 {
+		errDesc = errDesc[len(expected_prefix):len(errDesc)]
 	}
-	if strings.LastIndex(errDesc, ACTUAL_SUFFIX) > 0 {
-		errDesc = errDesc[0 : len(errDesc)-len(ACTUAL_SUFFIX)]
+	if strings.LastIndex(errDesc, actual_prefix) > 0 {
+		errDesc = errDesc[0 : len(errDesc)-len(actual_prefix)]
 	}
 
 	errFile := err.Path
@@ -210,21 +210,22 @@ func errorSummary(err *revel.Error) (message string) {
 	}
 
 	message = fmt.Sprintf("%s %s#%d", errDesc, errFile, err.Line)
-	return
 
-	// If line of error isn't known return the message as is.
-	if err.Line == 0 {
-		return
-	}
-
-	// Otherwise, include info about the line number and the relevant
-	// source code lines.
-	message += fmt.Sprintf(" (around line %d): ", err.Line)
-	for _, line := range err.ContextSource() {
-		if line.IsError {
-			message += line.Source
+	/*
+		// If line of error isn't known return the message as is.
+		if err.Line == 0 {
+			return
 		}
-	}
+
+		// Otherwise, include info about the line number and the relevant
+		// source code lines.
+		message += fmt.Sprintf(" (around line %d): ", err.Line)
+		for _, line := range err.ContextSource() {
+			if line.IsError {
+				message += line.Source
+			}
+		}
+	*/
 
 	return
 }
@@ -253,12 +254,12 @@ func formatResponse(t testing.TestSuite) map[string]string {
 	}
 }
 
-//functions needed to sort the testsuites by name.
-type SortBySuiteName []interface{}
+//sortbySuiteName sorts the testsuites by name.
+type sortBySuiteName []interface{}
 
-func (a SortBySuiteName) Len() int      { return len(a) }
-func (a SortBySuiteName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a SortBySuiteName) Less(i, j int) bool {
+func (a sortBySuiteName) Len() int      { return len(a) }
+func (a sortBySuiteName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a sortBySuiteName) Less(i, j int) bool {
 	return reflect.TypeOf(a[i]).Elem().Name() < reflect.TypeOf(a[j]).Elem().Name()
 }
 
@@ -269,7 +270,7 @@ func init() {
 	revel.OnAppStart(func() {
 		// Extracting info about available test suites from revel/testing package.
 		registeredTests = map[string]int{}
-		sort.Sort(SortBySuiteName(testing.TestSuites))
+		sort.Sort(sortBySuiteName(testing.TestSuites))
 		for _, testSuite := range testing.TestSuites {
 			testSuites = append(testSuites, describeSuite(testSuite))
 		}

--- a/testrunner/app/controllers/testrunner.go
+++ b/testrunner/app/controllers/testrunner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/revel/revel"
@@ -191,7 +192,25 @@ func describeSuite(testSuite interface{}) TestSuiteDesc {
 
 // errorSummary gets an error and returns its summary in human readable format.
 func errorSummary(err *revel.Error) (message string) {
-	message = fmt.Sprintf("%4sStatus: %s\n%4sIn %s", "", err.Description, "", err.Path)
+	EXPECTED_PREFIX := "(expected)"
+	ACTUAL_SUFFIX := "(actual)"
+	errDesc := err.Description
+	//strip the actual/expected stuff to provide more condensed display.
+	if strings.Index(errDesc, EXPECTED_PREFIX) == 0 {
+		errDesc = errDesc[len(EXPECTED_PREFIX):len(errDesc)]
+	}
+	if strings.LastIndex(errDesc, ACTUAL_SUFFIX) > 0 {
+		errDesc = errDesc[0 : len(errDesc)-len(ACTUAL_SUFFIX)]
+	}
+
+	errFile := err.Path
+	slashIdx := strings.LastIndex(errFile, "/")
+	if slashIdx > 0 {
+		errFile = errFile[slashIdx+1 : len(errFile)]
+	}
+
+	message = fmt.Sprintf("%s %s#%d", errDesc, errFile, err.Line)
+	return
 
 	// If line of error isn't known return the message as is.
 	if err.Line == 0 {
@@ -234,6 +253,15 @@ func formatResponse(t testing.TestSuite) map[string]string {
 	}
 }
 
+//functions needed to sort the testsuites by name.
+type SortBySuiteName []interface{}
+
+func (a SortBySuiteName) Len() int      { return len(a) }
+func (a SortBySuiteName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortBySuiteName) Less(i, j int) bool {
+	return reflect.TypeOf(a[i]).Elem().Name() < reflect.TypeOf(a[j]).Elem().Name()
+}
+
 func init() {
 	// Every time app is restarted convert the list of available test suites
 	// provided by the revel testing package into a format which will be used by
@@ -241,6 +269,7 @@ func init() {
 	revel.OnAppStart(func() {
 		// Extracting info about available test suites from revel/testing package.
 		registeredTests = map[string]int{}
+		sort.Sort(SortBySuiteName(testing.TestSuites))
 		for _, testSuite := range testing.TestSuites {
 			testSuites = append(testSuites, describeSuite(testSuite))
 		}

--- a/testrunner/app/views/TestRunner/Index.html
+++ b/testrunner/app/views/TestRunner/Index.html
@@ -18,7 +18,9 @@
         .table > tbody > tr > td { padding-top:1px; padding-bottom:2px; vertical-align: middle; }
         .passed td { background-color: #90EE90 !important; }
         .failed td { background-color: #FFB6C1 !important; }
-        .tests td.name, .tests td.result { }
+        td.result div.panel-default{ display:none; }
+        td.result > a { color: red; }
+        td.rightCol { width: 40px; }
         pre { font-size:10px; white-space: pre; }
         .panel-heading {
             padding: 2px 2px
@@ -33,7 +35,7 @@
         .panel-heading a.collapsed:after {
             content:"\25b6";
         }
-        .name { width: 50%; }
+        .name { width: 35%; }
         .w100 { width: 100%; }
         </style>
     </head>
@@ -60,8 +62,8 @@
                         {{range .Tests}}
                             <tr>
                                 <td class="name"><button data-test-file="{{$testFile}}" test="{{.Name}}" class="leftbutton btn btn-success btn-xs">Run</button>&nbsp;&nbsp;{{ .Name }}</td>
-                                <td class="result"></td>
-                                <td><button data-test-file="{{$testFile}}" test="{{.Name}}" class="pull-right btn btn-success btn-xs">Run</button></td>
+                                <td class="result"><a href="#"></a></td>
+                                <td class="rightCol"><button data-test-file="{{$testFile}}" test="{{.Name}}" class="pull-right btn btn-success btn-xs">Run</button></td>
                             </tr>
                         {{end}}
                     </table>
@@ -110,6 +112,11 @@
         addToQueue(button);
     });
 
+    $("td.result a").click(function() { //show/hide the extended error div
+        $(this).siblings().toggle();
+        return false;
+    });
+
     $("button[test-file]").click(function() {
         $("#allTestResults").text("");
         var testfile = $(this).attr('test-file');
@@ -155,6 +162,8 @@
         var test = button.attr("test");
         var row = button.parents("tr");
         var resultCell = row.children(".result");
+        $("a", resultCell).text("");
+        $("div.panel-default", resultCell).remove();
         $.ajax({
             dataType: "json",
             url: "{{url `Root`}}/@tests/"+suite+"/"+test,
@@ -163,11 +172,11 @@
                 if (result.Passed) {
                     console.log("pass: " + result.Name);
                     passCount++;
-                    resultCell.html("");
                 } else {
                     console.log("fail: result.Name");
                     failCount++;
-                    resultCell.html(result.ErrorHtml);
+                    $("a", resultCell).text(result.ErrorSummary);
+                    resultCell.append(result.ErrorHTML);
 
                     $("#result_" + suite + "_" + test + " pre code").each(function(i, block) {
                         hljs.highlightBlock(block);

--- a/testrunner/app/views/TestRunner/Index.html
+++ b/testrunner/app/views/TestRunner/Index.html
@@ -12,7 +12,7 @@
         header { background-color:#ADD8E6 }
         header h1 {margin-top: 10px; margin-bottom:20px;}
         header table {margin-bottom: 0px }
-        td .btn {margin-bottom: 1px; line-height: 1.0}
+        td .btn {margin-bottom: 1px; }
         button.file-test { margin-bottom: 0px; margin-left: 2px }
         table.tests tr { border-bottom: 1px solid #ddd; background-color: #f9f9f9; }
         .table > tbody > tr > td { padding-top:1px; padding-bottom:2px; vertical-align: middle; }
@@ -43,7 +43,7 @@
         <header>
             <div class="container">
                 <h1 class="pull-left">Test Runner <small>- Run your unit tests here.</small> </h1>
-                    <div style="margin-top:8px" class="pull-right">
+                    <div style="margin-top:16px" class="pull-right">
                         <button class="btn btn-success" all-tests="">Run All Tests</button>
                         <div><a class="small" href="#" id="allTestResults"></a></div>
                     </div>
@@ -54,8 +54,8 @@
             {{ $testFile := .Name }}
             <div style="margin-top:10px;" class="panel panel-default">
                 <div class="panel-heading">
-                    <button class="btn btn-xs btn-success file-test" test-file="{{.Name}}" class="btn btn-success btn-xs">Run</button>
-                    <span class="h5">&nbsp;<a class="collapseLnk" data-toggle="collapse" data-target="#{{.Name}}" href="#">{{.Name}}</a></span>
+                    <button class="btn btn-xs btn-success file-test" test-file="{{.Name}}">Run</button>
+                    <span class="h5">&nbsp;<a id="link-{{ $testFile }}" class="collapseLnk" data-toggle="collapse" data-target="#{{.Name}}" href="#">{{.Name}}</a></span>
                 </div>
                 <div id="{{.Name}}" class="panel-collapse collapse in">
                     <table class="panel-body table table-condensed tests" suite="{{.Name}}">
@@ -98,9 +98,10 @@
     });
 
     $("#allTestResults").click(function() {
-        var badRow = $("tr.failed").get(0);
-        if (badRow !== undefined) 
-            badRow.scrollIntoView();
+        var badRows = $("tr.failed");
+        if (badRows.length >= 0) {
+            badRows[0].scrollIntoView();
+        }
 
         return false;
     });
@@ -170,13 +171,18 @@
             success: function(result) {
                 row.attr("class", result.Passed ? "passed" : "failed");
                 if (result.Passed) {
-                    console.log("pass: " + result.Name);
                     passCount++;
                 } else {
                     console.log("fail: result.Name");
                     failCount++;
-                    $("a", resultCell).text(result.ErrorSummary);
+                    var resultLnk = $("a", resultCell);
+                    $(resultLnk).text(result.ErrorSummary);
                     resultCell.append(result.ErrorHTML);
+
+                    var pnlDiv = row.closest("div");
+                    if ($(pnlDiv).hasClass("in") == false) {
+                        $("#link-" + suite).click();
+                    }
 
                     $("#result_" + suite + "_" + test + " pre code").each(function(i, block) {
                         hljs.highlightBlock(block);


### PR DESCRIPTION
Enhancements to the test runner page:
  * order tests by suite name
  * condense the test failure message so it is easier to read/grok
  * clicking on error summary link toggles display of extended error message
  * increase width of the error display column
![condensed_error](https://cloud.githubusercontent.com/assets/1987922/7256676/6ef5fc34-e805-11e4-8a2e-e4e43b4b9d7c.png)
![expanded_error](https://cloud.githubusercontent.com/assets/1987922/7256678/7753baa6-e805-11e4-8d1d-376c06225289.png)

