### PR TITLE
Add authorization to jobs module

### DIFF
--- a/jobs/app/controllers/status.go
+++ b/jobs/app/controllers/status.go
@@ -1,9 +1,14 @@
 package controllers
 
 import (
-	"github.com/revel/revel"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
 	"github.com/revel/modules/jobs/app/jobs"
+	"github.com/revel/revel"
 	"github.com/robfig/cron"
+	"net/http"
 	"strings"
 )
 
@@ -11,18 +16,65 @@ type Jobs struct {
 	*revel.Controller
 }
 
-func (c Jobs) Status() revel.Result {
+func (c *Jobs) Status() revel.Result {
 	remoteAddress := c.Request.RemoteAddr
-	if revel.Config.BoolDefault("jobs.acceptproxyaddress", false) {
-		if proxiedAddress, isProxied := c.Request.Header["X-Forwarded-For"]; isProxied {
-			remoteAddress = proxiedAddress[0]
+	if revel.Config.BoolDefault("jobs.auth", false) {
+		user, found_user := revel.Config.String("jobs.auth.user")
+		pass, found_pass := revel.Config.String("jobs.auth.pass")
+
+		// Verify that a username and password are given in the config file
+		if !found_pass || !found_user {
+			return c.unauthorized()
+		}
+
+		// Verify that the Authorization header is received and valid
+		auth := strings.Split(c.Request.Header.Get("Authorization"), " ")
+		if len(auth) < 2 {
+			return c.unauthorized()
+		}
+
+		// Decode Authorization header
+		decoded, err := base64.StdEncoding.DecodeString(auth[1])
+		if err != nil {
+			return c.unauthorized()
+		}
+
+		// Split Authorization header to user and password
+		str := strings.Split(string(decoded), ":")
+
+		// If SHA256 is enabled, hash received password
+		is_sha256 := revel.Config.BoolDefault("jobs.auth.sha256", false)
+		if is_sha256 {
+			hash := sha256.Sum256([]byte(str[1]))
+			str[1] = string(hex.EncodeToString(hash[:]))
+			pass = strings.ToLower(pass)
+		}
+
+		// Compare user and password
+		if user != str[0] || pass != str[1] {
+			revel.WARN.Println("Attempted login to /@jobs with invalid credentials")
+			return c.unauthorized()
+		}
+
+	} else {
+		if revel.Config.BoolDefault("jobs.acceptproxyaddress", false) {
+			if proxiedAddress, isProxied := c.Request.Header["X-Forwarded-For"]; isProxied {
+				remoteAddress = proxiedAddress[0]
+			}
+		}
+		if !strings.HasPrefix(remoteAddress, "127.0.0.1") && !strings.HasPrefix(remoteAddress, "::1") {
+			return c.Forbidden("%s is not local", remoteAddress)
 		}
 	}
-	if !strings.HasPrefix(remoteAddress, "127.0.0.1") && !strings.HasPrefix(remoteAddress, "::1") {
-		return c.Forbidden("%s is not local", remoteAddress)
-	}
+
 	entries := jobs.MainCron.Entries()
 	return c.Render(entries)
+}
+
+func (c *Jobs) unauthorized() revel.Result {
+	c.Response.Status = http.StatusUnauthorized
+	c.Response.Out.Header().Set("WWW-Authenticate", "Basic realm=\"revel jobs\"")
+	return c.RenderError(errors.New("401: Not Authorized"))
 }
 
 func init() {


### PR DESCRIPTION
This change will allow users to require authentication via HTTP Basic Authentication prior to accessing the /@jobs page.

It introduces the following config options:
- `jobs.auth` (bool, default=`false`)  Is authentication required?
- `jobs.auth.user` (string) Required username
- `jobs.auth.pass` (string) Required password (or its SHA-256-hash, if `jobs.auth.sha256` is `true`)
- `jobs.auth.sha256` (bool, default=`false`) Is the password SHA-256-hashed? You probably don't want your passwords in clear text in config files.

If no user and pass is specified in the config, access will always be denied.
If authorization is enabled, local IP checking will be disabled.

_This feature was requested at [the `jobs` documentation page](http://revel.github.io/manual/jobs.html#future-areas-for-development), so I felt free to implement it._
