### PR TITLE
Gorm - support for non-default database port

### DIFF
--- a/orm/gorm/README.md
+++ b/orm/gorm/README.md
@@ -21,6 +21,7 @@ module.gorm = github.com/revel/modules/orm/gorm
 db.autoinit=true # default=true
 db.driver=sqlite3 # mysql, postgres, sqlite3
 db.host=/tmp/app.db  # Use db.host /tmp/app.db is your driver is sqlite
+#db.port=dbport # when the port is not used the default of each driver
 #db.user=dbuser
 #db.name=dbname
 #db.password=dbpassword


### PR DESCRIPTION
Fixes #63 

Now you can specify the database port.
When the port is not specified, the default port of each driver is used